### PR TITLE
fix(server.go): close the request body after processing to fix resource leak bug

### DIFF
--- a/server.go
+++ b/server.go
@@ -32,6 +32,9 @@ func invokeHandler(w http.ResponseWriter, req *http.Request) {
 	if err != nil {
 		panic(err)
 	}
+
+	defer req.Body.Close() // fix: Close the request body after processing to fix resource leak bug
+
 	fcCtx := NewFromContext(req)
 
 	resp, err := handler(fcCtx, event)


### PR DESCRIPTION
The change adds a defer statement to close the request body after processing. 
This fixes a resource leak bug where the request body was not being closed, potentially leading to resource exhaustion.